### PR TITLE
Extend NEG for Migration from DMP

### DIFF
--- a/src/main/webapp/einzelbeleg.jsp
+++ b/src/main/webapp/einzelbeleg.jsp
@@ -184,6 +184,58 @@
                                         </tr>
 				</tbody>
 			</table>
+                        <br>
+                        <!-- Raster Group (same style as date group)-->
+                        <table class="date">
+				<tbody>
+					<tr>
+						<th class="date" colspan="2">
+                                                    <% Language.printTextfield(out, session, formular, "Grid"); %>
+                                                </th>
+					</tr>
+                                        <tr>
+						<td width="200">
+                                                    <% Language.printDatafield(out,session, formular,"Seite");%>
+                                                </td>
+						<td width="450">
+                                                        <jsp:include page="inc.erzeugeFormular.jsp">
+								<jsp:param name="ID" value="<%=id%>" />
+								<jsp:param name="Formular" value="einzelbeleg" />
+								<jsp:param name="Datenfeld" value="Seite" />
+								<jsp:param name="size" value="5" />
+							</jsp:include>
+                                                </td>
+					</tr>
+                                        
+                                        <tr>
+						<td width="200">
+                                                    <% Language.printDatafield(out,session, formular,"Raster");%>
+                                                </td>
+						<td width="450">
+                                                        <jsp:include page="inc.erzeugeFormular.jsp">
+								<jsp:param name="ID" value="<%=id%>" />
+								<jsp:param name="Formular" value="einzelbeleg" />
+								<jsp:param name="Datenfeld" value="Raster" />
+								<jsp:param name="size" value="5" />
+							</jsp:include>
+                                                </td>
+					</tr>
+                                        
+                                        <tr>
+						<td width="200">
+                                                    <% Language.printDatafield(out,session, formular,"Schreiber");%>
+                                                </td>
+						<td width="450">
+                                                        <jsp:include page="inc.erzeugeFormular.jsp">
+								<jsp:param name="ID" value="<%=id%>" />
+								<jsp:param name="Formular" value="einzelbeleg" />
+								<jsp:param name="Datenfeld" value="Schreiber" />
+								<jsp:param name="size" value="5" />
+							</jsp:include>
+                                                </td>
+					</tr>
+				</tbody>
+			</table>
 			<br>
 			<table class="date">
 				<tbody>

--- a/src/main/webapp/einzelbeleg.jsp
+++ b/src/main/webapp/einzelbeleg.jsp
@@ -88,6 +88,32 @@
 									<jsp:param name="title" value="einzelbeleg" />
 								</jsp:include></span></td>
 					</tr>
+                                        <tr>
+						<td width="200">
+                                                    <% Language.printDatafield(out,session, formular,"PalAbgrenzung");%>
+                                                </td>
+						<td width="450">
+                                                        <jsp:include page="inc.erzeugeFormular.jsp">
+								<jsp:param name="ID" value="<%=id%>" />
+								<jsp:param name="Formular" value="einzelbeleg" />
+								<jsp:param name="Datenfeld" value="PalAbgrenzung" />
+								<jsp:param name="size" value="5" />
+							</jsp:include>
+                                                </td>
+					</tr>
+                                        <tr>
+						<td width="200">
+                                                    <% Language.printDatafield(out,session, formular,"InhAbgrenzung");%>
+                                                </td>
+						<td width="450">
+                                                        <jsp:include page="inc.erzeugeFormular.jsp">
+								<jsp:param name="ID" value="<%=id%>" />
+								<jsp:param name="Formular" value="einzelbeleg" />
+								<jsp:param name="Datenfeld" value="InhAbgrenzung" />
+								<jsp:param name="size" value="5" />
+							</jsp:include>
+                                                </td>
+					</tr>
 					<tr>
 						<td width="200" valign="top">
                                                     <% Language.printDatafield(out,session, formular,"Lemma");%>

--- a/src/main/webapp/einzelbeleg.jsp
+++ b/src/main/webapp/einzelbeleg.jsp
@@ -114,6 +114,19 @@
 							</jsp:include>
                                                 </td>
 					</tr>
+                                        <tr>
+						<td width="200">
+                                                    <% Language.printDatafield(out,session, formular,"NrInStrukt");%>
+                                                </td>
+						<td width="450">
+                                                        <jsp:include page="inc.erzeugeFormular.jsp">
+								<jsp:param name="ID" value="<%=id%>" />
+								<jsp:param name="Formular" value="einzelbeleg" />
+								<jsp:param name="Datenfeld" value="NrInStrukt" />
+								<jsp:param name="size" value="5" />
+							</jsp:include>
+                                                </td>
+					</tr>
 					<tr>
 						<td width="200" valign="top">
                                                     <% Language.printDatafield(out,session, formular,"Lemma");%>

--- a/src/main/webapp/gast/einzelbeleg.jsp
+++ b/src/main/webapp/gast/einzelbeleg.jsp
@@ -166,6 +166,39 @@
         </jsp:include>
       </td>
     </tr>
+    <tr>
+      <th><% Language.printDatafield(out, session, "einzelbeleg", "PalAbgrenzung"); %></th>
+      <td>
+        <jsp:include page="../inc.erzeugeFormular.jsp">
+          <jsp:param name="ID" value="<%= id %>"/>
+          <jsp:param name="Formular" value="einzelbeleg"/>
+          <jsp:param name="Datenfeld" value="PalAbgrenzung"/>
+          <jsp:param name="Readonly" value="yes"/>
+        </jsp:include>
+      </td>
+    </tr>
+    <tr>
+      <th><% Language.printDatafield(out, session, "einzelbeleg", "InhAbgrenzung"); %></th>
+      <td>
+        <jsp:include page="../inc.erzeugeFormular.jsp">
+          <jsp:param name="ID" value="<%= id %>"/>
+          <jsp:param name="Formular" value="einzelbeleg"/>
+          <jsp:param name="Datenfeld" value="InhAbgrenzung"/>
+          <jsp:param name="Readonly" value="yes"/>
+        </jsp:include>
+      </td>
+    </tr>
+    <tr>
+      <th><% Language.printDatafield(out, session, "einzelbeleg", "NrInStrukt"); %></th>
+      <td>
+        <jsp:include page="../inc.erzeugeFormular.jsp">
+          <jsp:param name="ID" value="<%= id %>"/>
+          <jsp:param name="Formular" value="einzelbeleg"/>
+          <jsp:param name="Datenfeld" value="Konvent"/>
+          <jsp:param name="Readonly" value="yes"/>
+        </jsp:include>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/main/webapp/gast/einzelbeleg.jsp
+++ b/src/main/webapp/gast/einzelbeleg.jsp
@@ -194,7 +194,7 @@
         <jsp:include page="../inc.erzeugeFormular.jsp">
           <jsp:param name="ID" value="<%= id %>"/>
           <jsp:param name="Formular" value="einzelbeleg"/>
-          <jsp:param name="Datenfeld" value="Konvent"/>
+          <jsp:param name="Datenfeld" value="NrInStrukt"/>
           <jsp:param name="Readonly" value="yes"/>
         </jsp:include>
       </td>

--- a/src/main/webapp/gast/einzelbeleg.jsp
+++ b/src/main/webapp/gast/einzelbeleg.jsp
@@ -221,6 +221,39 @@
         </jsp:include>
       </td>
     </tr>
+    <tr>
+      <th><% Language.printDatafield(out, session, "einzelbeleg", "Seite"); %></th>
+      <td>
+        <jsp:include page="../inc.erzeugeFormular.jsp">
+          <jsp:param name="ID" value="<%= id %>"/>
+          <jsp:param name="Formular" value="einzelbeleg"/>
+          <jsp:param name="Datenfeld" value="Seite"/>
+          <jsp:param name="Readonly" value="yes"/>
+        </jsp:include>
+      </td>
+    </tr>
+    <tr>
+      <th><% Language.printDatafield(out, session, "einzelbeleg", "Raster"); %></th>
+      <td>
+        <jsp:include page="../inc.erzeugeFormular.jsp">
+          <jsp:param name="ID" value="<%= id %>"/>
+          <jsp:param name="Formular" value="einzelbeleg"/>
+          <jsp:param name="Datenfeld" value="Raster"/>
+          <jsp:param name="Readonly" value="yes"/>
+        </jsp:include>
+      </td>
+    </tr>
+    <tr>
+      <th><% Language.printDatafield(out, session, "einzelbeleg", "Schreiber"); %></th>
+      <td>
+        <jsp:include page="../inc.erzeugeFormular.jsp">
+          <jsp:param name="ID" value="<%= id %>"/>
+          <jsp:param name="Formular" value="einzelbeleg"/>
+          <jsp:param name="Datenfeld" value="Schreiber"/>
+          <jsp:param name="Readonly" value="yes"/>
+        </jsp:include>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/updates/22.sql
+++ b/updates/22.sql
@@ -9,3 +9,9 @@ ALTER TABLE einzelbeleg ADD inh_abgrenzung VARCHAR(10) DEFAULT NULL;
 /*Create the datamapping for the inh_abgrenzung attribute of the einzelbeleg form*/
 INSERT INTO datenbank_mapping (Formular, Datenfeld, de_Beschriftung, Feldtyp, Array, ZielTabelle, ZielAttribut, Auswahlherkunft, Seite, gb_beschriftung, fr_beschriftung, la_beschriftung)
 VALUES ("einzelbeleg", "InhAbgrenzung", "Inh Abgrenzung", "textfield", 0, "einzelbeleg", "inh_abgrenzung", "", "einzelbeleg", "Inh Demarcation", "Inh Démarcation", "Inh Signatio");
+
+ALTER TABLE einzelbeleg ADD nr_in_strukt VARCHAR(10) DEFAULT NULL;
+
+/*Create the datamapping for the nr_in_strukt attribute of the einzelbeleg form*/
+INSERT INTO datenbank_mapping (Formular, Datenfeld, de_Beschriftung, Feldtyp, Array, ZielTabelle, ZielAttribut, Auswahlherkunft, Seite, gb_beschriftung, fr_beschriftung, la_beschriftung)
+VALUES ("einzelbeleg", "NrInStrukt", "Nummer in Struktur", "textfield", 0, "einzelbeleg", "nr_in_strukt", "", "einzelbeleg", "Number in structure", "Nombre dans la structure", "Numerus in structuram");

--- a/updates/22.sql
+++ b/updates/22.sql
@@ -1,0 +1,11 @@
+ALTER TABLE einzelbeleg ADD pal_abgrenzung VARCHAR(10) DEFAULT NULL;
+
+/*Create the datamapping for the pal_abgrenzung attribute of the einzelbeleg form*/
+INSERT INTO datenbank_mapping (Formular, Datenfeld, de_Beschriftung, Feldtyp, Array, ZielTabelle, ZielAttribut, Auswahlherkunft, Seite, gb_beschriftung, fr_beschriftung, la_beschriftung)
+VALUES ("einzelbeleg", "PalAbgrenzung", "Pal Abgrenzung", "textfield", 0, "einzelbeleg", "pal_abgrenzung", "", "einzelbeleg", "Pal Demarcation", "Pal Démarcation", "Pal Signatio");
+
+ALTER TABLE einzelbeleg ADD inh_abgrenzung VARCHAR(10) DEFAULT NULL;
+
+/*Create the datamapping for the inh_abgrenzung attribute of the einzelbeleg form*/
+INSERT INTO datenbank_mapping (Formular, Datenfeld, de_Beschriftung, Feldtyp, Array, ZielTabelle, ZielAttribut, Auswahlherkunft, Seite, gb_beschriftung, fr_beschriftung, la_beschriftung)
+VALUES ("einzelbeleg", "InhAbgrenzung", "Inh Abgrenzung", "textfield", 0, "einzelbeleg", "inh_abgrenzung", "", "einzelbeleg", "Inh Demarcation", "Inh Démarcation", "Inh Signatio");

--- a/updates/27.sql
+++ b/updates/27.sql
@@ -1,17 +1,57 @@
+/*
+FELD: pal_abgrenzung
+*/
 ALTER TABLE einzelbeleg ADD pal_abgrenzung VARCHAR(10) DEFAULT NULL;
 
 /*Create the datamapping for the pal_abgrenzung attribute of the einzelbeleg form*/
 INSERT INTO datenbank_mapping (Formular, Datenfeld, de_Beschriftung, Feldtyp, Array, ZielTabelle, ZielAttribut, Auswahlherkunft, Seite, gb_beschriftung, fr_beschriftung, la_beschriftung)
 VALUES ("einzelbeleg", "PalAbgrenzung", "Pal Abgrenzung", "textfield", 0, "einzelbeleg", "pal_abgrenzung", "", "einzelbeleg", "Pal Demarcation", "Pal Démarcation", "Pal Signatio");
 
+/*
+FELD: inh_abgrenzung
+*/
 ALTER TABLE einzelbeleg ADD inh_abgrenzung VARCHAR(10) DEFAULT NULL;
 
 /*Create the datamapping for the inh_abgrenzung attribute of the einzelbeleg form*/
 INSERT INTO datenbank_mapping (Formular, Datenfeld, de_Beschriftung, Feldtyp, Array, ZielTabelle, ZielAttribut, Auswahlherkunft, Seite, gb_beschriftung, fr_beschriftung, la_beschriftung)
 VALUES ("einzelbeleg", "InhAbgrenzung", "Inh Abgrenzung", "textfield", 0, "einzelbeleg", "inh_abgrenzung", "", "einzelbeleg", "Inh Demarcation", "Inh Démarcation", "Inh Signatio");
 
+/*
+FELD: nr_in_strukt
+*/
 ALTER TABLE einzelbeleg ADD nr_in_strukt VARCHAR(10) DEFAULT NULL;
 
 /*Create the datamapping for the nr_in_strukt attribute of the einzelbeleg form*/
 INSERT INTO datenbank_mapping (Formular, Datenfeld, de_Beschriftung, Feldtyp, Array, ZielTabelle, ZielAttribut, Auswahlherkunft, Seite, gb_beschriftung, fr_beschriftung, la_beschriftung)
 VALUES ("einzelbeleg", "NrInStrukt", "Nummer in Struktur", "textfield", 0, "einzelbeleg", "nr_in_strukt", "", "einzelbeleg", "Number in structure", "Nombre dans la structure", "Numerus in structuram");
+
+/*
+FELD: seite
+*/
+ALTER TABLE einzelbeleg ADD seite VARCHAR(10) DEFAULT NULL;
+
+/*Create the datamapping for the seite attribute of the einzelbeleg form*/
+INSERT INTO datenbank_mapping (Formular, Datenfeld, de_Beschriftung, Feldtyp, Array, ZielTabelle, ZielAttribut, Auswahlherkunft, Seite, gb_beschriftung, fr_beschriftung, la_beschriftung)
+VALUES ("einzelbeleg", "Seite", "Seite", "textfield", 0, "einzelbeleg", "seite", "", "einzelbeleg", "Site", "Page", "Page");
+
+/*
+FELD: raster
+*/
+ALTER TABLE einzelbeleg ADD raster VARCHAR(10) DEFAULT NULL;
+
+/*Create the datamapping for the raster attribute of the einzelbeleg form*/
+INSERT INTO datenbank_mapping (Formular, Datenfeld, de_Beschriftung, Feldtyp, Array, ZielTabelle, ZielAttribut, Auswahlherkunft, Seite, gb_beschriftung, fr_beschriftung, la_beschriftung)
+VALUES ("einzelbeleg", "Raster", "Raster", "textfield", 0, "einzelbeleg", "raster", "", "einzelbeleg", "Grid", "Grille", "Eget");
+
+/*
+FELD: schreiber
+*/
+ALTER TABLE einzelbeleg ADD schreiber VARCHAR(10) DEFAULT NULL;
+
+/*Create the datamapping for the schreiber attribute of the einzelbeleg form*/
+INSERT INTO datenbank_mapping (Formular, Datenfeld, de_Beschriftung, Feldtyp, Array, ZielTabelle, ZielAttribut, Auswahlherkunft, Seite, gb_beschriftung, fr_beschriftung, la_beschriftung)
+VALUES ("einzelbeleg", "Schreiber", "Schreiber", "textfield", 0, "einzelbeleg", "schreiber", "", "einzelbeleg", "Writer", "Scribe", "Scribae");
+
+/*Insert Group Label*/
+INSERT INTO datenbank_texte (Formular, Textfeld, de, gb, fr, la) VALUES ('einzelbeleg', 'Grid', 'Raster', 'Grid', 'Grille', 'Eget');
+


### PR DESCRIPTION
Workshop 26.09.
Fields are missing in NeG:

1. pal_abgrenzung
2. nr_in_strukt
3. inh_abgrenzung

4. seite
5. raster
6. schreiber

This PR includes the implementation of the 6 Fields (Database, Frontend, Backend)

### Backend:
![image](https://github.com/ubtue/neg/assets/104774773/a4eb84f4-35b1-4593-9c0d-97756eb95626)

![image](https://github.com/ubtue/neg/assets/104774773/8d357fe2-74b5-47b5-a99a-1ab23d61ced1)


### Frontend
![image](https://github.com/ubtue/neg/assets/104774773/9a02b0f7-b1a6-4ab3-b6ca-0ef75587265e)