### PR TITLE
Bugfix Personen andere Namen and delete andere Namen Bugfix

### DIFF
--- a/src/main/java/de/uni_tuebingen/ub/nppm/util/DeleteHelper.java
+++ b/src/main/java/de/uni_tuebingen/ub/nppm/util/DeleteHelper.java
@@ -52,6 +52,9 @@ public class DeleteHelper {
                     case "person_hatareal":
                         PersonDB.remove(PersonAreal_MM.class, id);
                         break;
+                    case "person_variante":
+                        PersonDB.remove(PersonVariante.class, id);
+                        break;
                     case "person_hatethnie":
                         PersonDB.remove(PersonEthnie_MM.class, id);
                         break;

--- a/src/main/webapp/dosave.jsp
+++ b/src/main/webapp/dosave.jsp
@@ -250,7 +250,7 @@
                     }
                 } // ENDE Datensatz neu
             } // ENDE Bemerkungsfeld
-            // Namenkommentar Editor
+           // Namenkommentar Editor
             else if (feldtyp != null && feldtyp.equals("nkeditor") && zieltabelle != null) {
                 String temp_datenfeld = request.getParameter(datenfeld);
 
@@ -260,11 +260,22 @@
                             SimpleDateFormat sf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
                             String formattedDate = sf.format(d);
 
-                            Map<String, String> valueMap = new HashMap<>();
-                            valueMap.put("NamenkommentarID", String.valueOf(id));
-                            valueMap.put("BenutzerID", String.valueOf(session.getAttribute("BenutzerID")));
-                            valueMap.put("Zeitstempel", formattedDate);
-                            SaveHelper.insert(zieltabelle, valueMap);
+                            if(formularAttribut.equals("NamenkommentarID"))
+                            {
+                                Map<String, String> valueMap = new HashMap<>();
+                                valueMap.put("NamenkommentarID", String.valueOf(id));
+                                valueMap.put("BenutzerID", String.valueOf(session.getAttribute("BenutzerID")));
+                                valueMap.put("Zeitstempel", formattedDate);
+                                SaveHelper.insert(zieltabelle, valueMap);
+                            }
+                            else if(formularAttribut.equals("MGHLemmaID"))
+                            {
+                                Map<String, String> valueMap = new HashMap<>();
+                                valueMap.put("MGHLemmaID", String.valueOf(id));
+                                valueMap.put("BenutzerID", String.valueOf(session.getAttribute("BenutzerID")));
+                                valueMap.put("Zeitstempel", formattedDate);
+                                SaveHelper.insert(zieltabelle, valueMap);
+                            }
                 }
             } // ENDE NamenkommentarEditor
             // combined

--- a/src/main/webapp/dosave.jsp
+++ b/src/main/webapp/dosave.jsp
@@ -250,7 +250,7 @@
                     }
                 } // ENDE Datensatz neu
             } // ENDE Bemerkungsfeld
-           // Namenkommentar Editor
+          // Namenkommentar Editor
             else if (feldtyp != null && feldtyp.equals("nkeditor") && zieltabelle != null) {
                 String temp_datenfeld = request.getParameter(datenfeld);
 
@@ -260,22 +260,20 @@
                             SimpleDateFormat sf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
                             String formattedDate = sf.format(d);
 
+                            Map<String, String> valueMap = new HashMap<>();
+
                             if(formularAttribut.equals("NamenkommentarID"))
                             {
-                                Map<String, String> valueMap = new HashMap<>();
                                 valueMap.put("NamenkommentarID", String.valueOf(id));
-                                valueMap.put("BenutzerID", String.valueOf(session.getAttribute("BenutzerID")));
-                                valueMap.put("Zeitstempel", formattedDate);
-                                SaveHelper.insert(zieltabelle, valueMap);
                             }
                             else if(formularAttribut.equals("MGHLemmaID"))
                             {
-                                Map<String, String> valueMap = new HashMap<>();
                                 valueMap.put("MGHLemmaID", String.valueOf(id));
-                                valueMap.put("BenutzerID", String.valueOf(session.getAttribute("BenutzerID")));
-                                valueMap.put("Zeitstempel", formattedDate);
-                                SaveHelper.insert(zieltabelle, valueMap);
                             }
+
+                            valueMap.put("BenutzerID", String.valueOf(session.getAttribute("BenutzerID")));
+                            valueMap.put("Zeitstempel", formattedDate);
+                            SaveHelper.insert(zieltabelle, valueMap);
                 }
             } // ENDE NamenkommentarEditor
             // combined

--- a/src/main/webapp/forms/array.addselect.jsp
+++ b/src/main/webapp/forms/array.addselect.jsp
@@ -38,21 +38,27 @@
                 out.println("</select>");
             }
             out.println("</td>");
-            String href = "javascript:deleteEntry('" + zielTabelle + "', '" + value_id + "', '" + returnpage + "', '" + id + "');";
-            out.println("<td>");
+
             if (!isReadOnly) {
-                out.println("<a href=\"" + href + "\">");
-                out.println(txt_delete);
-                out.println("</a>");
+
+                if (!selected.equals("1")) {
+                    String href = "javascript:deleteEntry('" + zielTabelle + "', '" + value_id + "', '" + returnpage + "', '" + id + "');";
+                    out.println("<td>");
+                    out.println("<a href=\"" + href + "\">");
+                    out.println(txt_delete);
+                    out.println("</a>");
+                    out.println("</td>");
+                } else {
+                    out.println("<td>&nbsp;</td><td><a href=\"javascript:popup('addselect', this, '" + auswahlherkunft + "', '" + datenfeld + "[" + i + "]', '');\">" + txt_newentry + "</a></td>");
+                }
             }
-            out.println("</td>");
 
             out.println("</tr>");
             i++;
         }
 
         //Create new drop down list when Backend/Admin, not Guest
-        if ((!isReadOnly)) {
+        if (!isReadOnly && !selected.equals("1")) {
 
             out.println("<tr>");
             out.println("<td>");
@@ -65,8 +71,8 @@
                 String value2_Bezeichnung = columns2[1].toString();
                 out.print("<option value=\"" + value2_id + "\">" + DBtoHTML(value2_Bezeichnung) + "</option>");
             }
-             out.println("</select>");
-             out.println("<td>&nbsp;</td><td><a href=\"javascript:popup('addselect', this, '" + auswahlherkunft + "', '" + datenfeld + "[" + i + "]', '');\">" + txt_newentry + "</a></td>");
+            out.println("</select>");
+            out.println("<td>&nbsp;</td><td><a href=\"javascript:popup('addselect', this, '" + auswahlherkunft + "', '" + datenfeld + "[" + i + "]', '');\">" + txt_newentry + "</a></td>");
         }
 
         out.println("</td>");

--- a/src/main/webapp/forms/array.textfield.jsp
+++ b/src/main/webapp/forms/array.textfield.jsp
@@ -50,7 +50,7 @@
         }
 
          //Create new drop down list when Backend/Admin, not Guest
-        if ((!isReadOnly)) {
+        if (!isReadOnly) {
             Integer maxLength = AbstractBase.getMaxCharacterLength(zielTabelle, zielAttribut);
             out.println("<tr>");
             out.println("<td>");
@@ -60,6 +60,5 @@
         }
 
         out.println("</table>");
-
     }
 %>

--- a/src/main/webapp/forms/array.textfield.jsp
+++ b/src/main/webapp/forms/array.textfield.jsp
@@ -48,6 +48,17 @@
             out.println("</tr>");
             i++;
         }
+
+         //Create new drop down list when Backend/Admin, not Guest
+        if ((!isReadOnly)) {
+            Integer maxLength = AbstractBase.getMaxCharacterLength(zielTabelle, zielAttribut);
+            out.println("<tr>");
+            out.println("<td>");
+            out.print("<input name=\"" + datenfeld + "[" + i + "]\" " + (size > 0 ? "size=\"" + size + "\" " : "") + "maxlength=\"" + ((maxLength != null) ? maxLength : "") + "\" />");
+            out.println("</td>");
+            out.println("</tr>");
+        }
+
         out.println("</table>");
 
     }

--- a/src/main/webapp/forms/noarray.addselect.jsp
+++ b/src/main/webapp/forms/noarray.addselect.jsp
@@ -5,16 +5,17 @@
     if (feldtyp.equals("addselect") && !array) {
         out.println("<select name=\"" + datenfeld + "\" id=\"" + datenfeld + "\">");
 
-        int selected = AbstractBase.getIntNative("SELECT " + zielAttribut + " FROM " + zielTabelle + " WHERE ID=\"" + id + "\"");
+        Integer selected = AbstractBase.getIntNative("SELECT " + zielAttribut + " FROM " + zielTabelle + " WHERE ID=\"" + id + "\"");
+        int selectedValue = (selected != null) ? selected : 0; // Falls die Abfrage null ist, wird 0 als Default-Wert verwendet
+
         List<Object[]> rows2 = AbstractBase.getListNative("SELECT ID, Bezeichnung FROM " + auswahlherkunft + " ORDER BY Bezeichnung ASC");
         for (Object[] columns2 : rows2) {
             int value2_id = Integer.parseInt(columns2[0].toString());
             String value2_Bezeichnung = columns2[1].toString();
-            out.println("<option value=\"" + value2_id + "\" " + ((value2_id == selected) ? "selected" : "") + ">" + DBtoHTML(value2_Bezeichnung) + "</option>");
+            out.println("<option value=\"" + value2_id + "\" " + ((value2_id == selectedValue) ? "selected" : "") + ">" + DBtoHTML(value2_Bezeichnung) + "</option>");
         }
         out.println("<td>&nbsp;</td><td><a href=\"javascript:popup('addselect', this, '" + auswahlherkunft + "', '" + datenfeld + "', '');\">" + txt_newentry + "</a></td>");
 
         out.println("</select>");
-
     }
 %>

--- a/src/main/webapp/forms/shortcut.jsp
+++ b/src/main/webapp/forms/shortcut.jsp
@@ -52,28 +52,32 @@
     String sql2 = sql + (sql.contains("WHERE") ? " AND" : " WHERE") + " " + title + ".ID = " + id + " ORDER BY ID DESC";
     String sql3 = sql + (sql.contains("WHERE") ? " AND" : " WHERE") + " " + title + ".ID > " + id + " ORDER BY ID ASC LIMIT 0,5";
 
-    List<Map> rowlist = AbstractBase.getMappedList(sql1);
+   List<Map> rowlist = AbstractBase.getMappedList(sql1);
     int count = 0;
     String res = "";
-    for (Map row: rowlist) {
+    for (Map row : rowlist) {
         count++;
-        if (count >= 5)
+        if (count >= 5) {
             break;
+        }
 
-        String value = format(row.get(bez).toString(), bez);
-        if (value != null) {
-            int max = Math.min(7, value.length());
-            if (bez.equals("PLemma")) {
-                int posAmph = value.substring(0, max).lastIndexOf("&");
-                int posSem = value.substring(0, max).lastIndexOf(";");
-                if (posAmph > posSem) {
-                    posSem = value.indexOf(";", posAmph);
-                    max = value.indexOf(";", posAmph) + 1;
+        Object valueObj = row.get(bez);
+        if (valueObj != null && !valueObj.toString().equals("")) {
+            String value = format(valueObj.toString(), bez);
+            if (value != null) {
+                int max = Math.min(7, value.length());
+                if (bez.equals("PLemma")) {
+                    int posAmph = value.substring(0, max).lastIndexOf("&");
+                    int posSem = value.substring(0, max).lastIndexOf(";");
+                    if (posAmph > posSem) {
+                        posSem = value.indexOf(";", posAmph);
+                        max = value.indexOf(";", posAmph) + 1;
+                    }
                 }
+                value = value.substring(0, max);
+                value = "<a style='color:#ffffff;' href='?ID=" + row.get("ID").toString() + "'>" + value + "..." + "</a>";
+                res = value + "\t" + res;
             }
-            value = value.substring(0, max);
-            value = "<a style='color:#ffffff;' href='?ID=" + row.get("ID").toString() + "'>" + value + "..." + "</a>";
-            res = value + "\t" + res;
         }
     }
     out.println(res);

--- a/src/main/webapp/gast/suche/freie_suche.jsp
+++ b/src/main/webapp/gast/suche/freie_suche.jsp
@@ -499,9 +499,9 @@
         fieldNames.add("selektion_quellengattung.Bezeichnung");
         if (!tableString.contains("selektion_quellengattung")) {
             tableString += " LEFT OUTER JOIN selektion_quellengattung ON einzelbeleg.QuelleGattungID=selektion_quellengattung.ID";
-        }
-        //headlines.add("Quellengattung");
-        headlines.add(DatenbankDB.getMapping(sprache, "freie_suche", "EinzelbelegQuellengattung"));
+    }
+
+    headlines.add(DatenbankDB.getMapping(sprache, "freie_suche", "QuelleGattung"));
 
         einzelbeleg = true;
     }


### PR DESCRIPTION
Bei (Backend) Personen wurde keine neue leere Textfield bei andere Namen erzeugt und das löschen von anderen Namen ging auch nicht mehr da ein eintrag in DeleteHelper für die tabelle person_variante gefehlt hat, alles behoben