### PR TITLE
README.md: innodb_buffer_pool_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Prerequisites:
 ```
 - Java >= 1.8.0_77
 - MySQL >= 5.7
+  - innodb_buffer_pool_size=256M
   - collation-server = utf8_unicode_ci
   - character-set-server = utf8mb4
   - group_concat_max_len = 100000000


### PR DESCRIPTION
Just for performance reasons, you should also add this on your local machine to `/etc/mysql/mysql.conf.d/mysqld.cnf` and execute `systemctl restart mysql` afterwards.