### PR TITLE
Bugfix navigation doppelt und überlappt entfernt

### DIFF
--- a/src/main/webapp/admin.auswahlfelder.jsp
+++ b/src/main/webapp/admin.auswahlfelder.jsp
@@ -5,9 +5,7 @@
 <%@ page import="de.uni_tuebingen.ub.nppm.db.SelektionDB" isThreadSafe="false" %>
 <%@ include file="configuration.jsp" %>
 
-<div>
-    <jsp:include page="layout/navigation.inc.jsp" />
-    <jsp:include page="layout/image.inc.html" />
+<div>    
     <jsp:include page="layout/titel.administration.jsp" />
     <div id="form">
 

--- a/src/main/webapp/admin.baumstruktur.jsp
+++ b/src/main/webapp/admin.baumstruktur.jsp
@@ -5,9 +5,7 @@
 <%@ page import="de.uni_tuebingen.ub.nppm.db.DatenbankDB" isThreadSafe="false" %>
 <%@ include file="configuration.jsp" %>
 
-<div>
-    <jsp:include page="layout/navigation.inc.jsp" />
-    <jsp:include page="layout/image.inc.html" />
+<div>    
     <jsp:include page="layout/titel.administration.jsp" />
     <div id="form">
 

--- a/src/main/webapp/admin.benutzer.neu.jsp
+++ b/src/main/webapp/admin.benutzer.neu.jsp
@@ -81,7 +81,7 @@
                     BenutzerDB.saveOrUpdate(benutzer);
 
                     out.println("<p>Benutzer \"" + request.getParameter("Benutzername") + "\"erfolgreich angelegt.</p>");
-                    out.println("<a href=\"administration.jsp\">zur&uuml;ck</a>");
+                    out.println("<a href=\"administration\">zur&uuml;ck</a>");
                 }
             %>
 

--- a/src/main/webapp/administration.jsp
+++ b/src/main/webapp/administration.jsp
@@ -12,20 +12,8 @@
         Language.setLanguage(request);
 %>
 
-<HEAD>
-    <TITLE>Nomen et Gens - Administration</TITLE>
-    <link rel="stylesheet" href="layout/layout.css" type="text/css">
-    <link rel="stylesheet" href="mktree.css" type="text/css">
-    <script type="text/javascript" src="mktree.js"></script>
-    <script src="javascript/funktionen.js" type="text/javascript"></script>
-    <noscript></noscript>
-</HEAD>
-
 <div>
-    <jsp:include page="layout/navigation.inc.jsp" />
-    <jsp:include page="layout/image.inc.html" />
     <jsp:include page="layout/titel.administration.jsp" />
-
     <div id="form">
         <div id="tab1">
             <div id="header">

--- a/src/main/webapp/edition.jsp
+++ b/src/main/webapp/edition.jsp
@@ -25,15 +25,14 @@
 </jsp:include>
 
   <div onLoad="javascript:onoff('tab4','tab1'); onoff('tab1','tab4');urlRewrite(<%= id %>);">
-    <FORM method="POST">
-      <jsp:include page="layout/navigation.inc.jsp" />
-      <jsp:include page="layout/image.inc.html" />
+    <FORM method="POST">      
       <jsp:include page="layout/titel.inc.jsp">
         <jsp:param name="title" value="Edition" />
         <jsp:param name="ID" value="<%= id %>" />
         <jsp:param name="size" value="" />
         <jsp:param name="Formular" value="edition" />
       </jsp:include>
+
       <jsp:include page="inc.erzeugeFormular.jsp">
         <jsp:param name="ID" value="<%= id %>"/>
         <jsp:param name="Formular" value="edition"/>

--- a/src/main/webapp/einzelbeleg.jsp
+++ b/src/main/webapp/einzelbeleg.jsp
@@ -31,9 +31,7 @@
 
 <div
     onLoad="javascript:onoff('tab4', 'tab1'); onoff('tab1', 'tab4');urlRewrite(<%=id%>);">
-    <FORM method="POST">
-        <jsp:include page="layout/navigation.inc.jsp" />
-        <jsp:include page="layout/image.inc.html" />
+    <FORM method="POST">        
         <jsp:include page="layout/titel.inc.jsp">
             <jsp:param name="title" value="Einzelbeleg" />
             <jsp:param name="ID" value="<%=id%>" />

--- a/src/main/webapp/einzelbeleg_comp.jsp
+++ b/src/main/webapp/einzelbeleg_comp.jsp
@@ -24,14 +24,16 @@
 </jsp:include>
 
 <div>
-<FORM method="POST"><jsp:include page="layout/navigation.inc.jsp" />
-<jsp:include page="layout/image.inc.html" /> <jsp:include
+<FORM method="POST">
+<jsp:include
 	page="layout/titel.inc.jsp">
 	<jsp:param name="title" value="Einzelbeleg" />
 	<jsp:param name="ID" value="<%= id %>" />
 	<jsp:param name="size" value="" />
 	<jsp:param name="Formular" value="einzelbeleg" />
-</jsp:include> <jsp:include page="inc.erzeugeFormular.jsp">
+</jsp:include>
+
+<jsp:include page="inc.erzeugeFormular.jsp">
 	<jsp:param name="ID" value="<%= id %>" />
 	<jsp:param name="Formular" value="einzelbeleg" />
 	<jsp:param name="Datenfeld" value="ID" />

--- a/src/main/webapp/freie_suche.jsp
+++ b/src/main/webapp/freie_suche.jsp
@@ -80,11 +80,7 @@
 
     <noscript></noscript>
 </div>
-
-
-
-    <jsp:include page="layout/navigation.inc.jsp" />
-    <jsp:include page="layout/image.inc.html" />
+    
     <jsp:include page="layout/titel.suche.html" />
 
     <FORM method="POST" action="suchergebnis">

--- a/src/main/webapp/handschrift.jsp
+++ b/src/main/webapp/handschrift.jsp
@@ -27,20 +27,21 @@
 
 <div
 	onLoad="javascript:onoff('tab2','tab1'); onoff('tab1','tab2');urlRewrite(<%=id%>);">
-<FORM method="POST"><jsp:include page="layout/navigation.inc.jsp" />
-<jsp:include page="layout/image.inc.html" /> <jsp:include
-	page="layout/titel.inc.jsp">
+<FORM method="POST">
+    <jsp:include page="layout/titel.inc.jsp">
 	<jsp:param name="formTitle" value="Textzeugen" />
 	<jsp:param name="title" value="Handschrift" />
 	<jsp:param name="ID" value="<%= id %>" />
 	<jsp:param name="size" value="" />
 	<jsp:param name="Formular" value="handschrift" />
-</jsp:include> <jsp:include page="inc.erzeugeFormular.jsp">
+    </jsp:include>
+
+    <jsp:include page="inc.erzeugeFormular.jsp">
 	<jsp:param name="ID" value="<%= id %>" />
 	<jsp:param name="Formular" value="handschrift" />
 	<jsp:param name="Datenfeld" value="ID" />
 	<jsp:param name="size" value="" />
-</jsp:include>
+    </jsp:include>
 
 <div id="form">
   <table style="width:100%;">

--- a/src/main/webapp/mghlemma.jsp
+++ b/src/main/webapp/mghlemma.jsp
@@ -29,9 +29,8 @@
 
 <div
 	onLoad="javascript:onoff('tab4','tab1'); onoff('tab1','tab4');urlRewrite(<%=id%>);">
-<FORM method="POST"><jsp:include page="layout/navigation.inc.jsp" />
-<jsp:include page="layout/image.inc.html" /> <jsp:include
-	page="layout/titel.inc.jsp">
+<FORM method="POST">
+ <jsp:include page="layout/titel.inc.jsp">
 	<jsp:param name="title" value="mgh_lemma" />
 	<jsp:param name="ID" value="<%= id %>" />
 	<jsp:param name="size" value="" />

--- a/src/main/webapp/namenkommentar.jsp
+++ b/src/main/webapp/namenkommentar.jsp
@@ -29,14 +29,15 @@
 
 <div
     onLoad="javascript:onoff('tab4', 'tab1'); onoff('tab1', 'tab4');urlRewrite(<%=id%>);">
-    <FORM method="POST"><jsp:include page="layout/navigation.inc.jsp" />
-        <jsp:include page="layout/image.inc.html" /> <jsp:include
+    <FORM method="POST">
+        <jsp:include
             page="layout/titel.inc.jsp">
             <jsp:param name="title" value="Namenkommentar" />
             <jsp:param name="ID" value="<%= id%>" />
             <jsp:param name="size" value="" />
             <jsp:param name="Formular" value="namenkommentar" />
         </jsp:include>
+
         <div id="form">
             <table style="width:100%;">
                 <tbody>

--- a/src/main/webapp/ohneVerknuepfung.jsp
+++ b/src/main/webapp/ohneVerknuepfung.jsp
@@ -9,8 +9,7 @@
   Language.setLanguage(request);
 %>
   <div>
-    <jsp:include page="layout/navigation.inc.jsp" />
-    <jsp:include page="layout/image.inc.html" />
+      
     <jsp:include page="layout/titel.suche.html" />
 
        <div id="form">

--- a/src/main/webapp/person.jsp
+++ b/src/main/webapp/person.jsp
@@ -29,14 +29,16 @@
 
 <div
     onLoad="javascript:onoff('tab4', 'tab1'); onoff('tab1', 'tab4');urlRewrite(<%=id%>);">
-    <FORM method="POST"><jsp:include page="layout/navigation.inc.jsp" />
-        <jsp:include page="layout/image.inc.html" /> <jsp:include
+    <FORM method="POST">
+         <jsp:include
             page="layout/titel.inc.jsp">
             <jsp:param name="title" value="Person" />
             <jsp:param name="ID" value="<%= id%>" />
             <jsp:param name="size" value="" />
             <jsp:param name="Formular" value="person" />
-        </jsp:include> <jsp:include page="inc.erzeugeFormular.jsp">
+        </jsp:include>
+
+        <jsp:include page="inc.erzeugeFormular.jsp">
             <jsp:param name="ID" value="<%= id%>" />
             <jsp:param name="Formular" value="person" />
             <jsp:param name="Datenfeld" value="ID" />

--- a/src/main/webapp/quelle.jsp
+++ b/src/main/webapp/quelle.jsp
@@ -36,14 +36,16 @@
 
 <div
     onLoad="javascript:onoff('tab4', 'tab1'); onoff('tab1', 'tab4');urlRewrite(<%=id%>);">
-    <FORM method="POST"><jsp:include page="layout/navigation.inc.jsp" />
-        <jsp:include page="layout/image.inc.html" /> <jsp:include
+    <FORM method="POST">
+        <jsp:include
             page="layout/titel.inc.jsp">
             <jsp:param name="title" value="Quelle" />
             <jsp:param name="ID" value="<%= id%>" />
             <jsp:param name="size" value="" />
             <jsp:param name="Formular" value="quelle" />
-        </jsp:include> <jsp:include page="inc.erzeugeFormular.jsp">
+        </jsp:include>
+
+        <jsp:include page="inc.erzeugeFormular.jsp">
             <jsp:param name="ID" value="<%= id%>" />
             <jsp:param name="Formular" value="quelle" />
             <jsp:param name="Datenfeld" value="ID" />


### PR DESCRIPTION
In einzelbeleg.jsp war die navigation unnötiger weise integriert, wurde nun entfernt, im naiser_design habe ich es auch entfernt dort hat es verursacht das ich einzelbelege nicht mehr speichern kann.