### PR TITLE
noarray.dateRO.jsp: Fix NULL-value related display problem

### DIFF
--- a/src/main/webapp/forms/noarray.dateRO.jsp
+++ b/src/main/webapp/forms/noarray.dateRO.jsp
@@ -27,16 +27,8 @@
             int resultIndex = 0;
             for (String zielattribut : zielattributArray) {
                 String zielattributGen = "Genauigkeit" + zielattribut;
-                if (row.get(zielattributGen) != null) {
-                    results[resultIndex++] = row.get(zielattributGen).toString();
-                } else {
-                    results[resultIndex++] = null;
-                }
-                if (row.get(zielattribut) != null) {
-                    results[resultIndex++] = row.get(zielattribut).toString();
-                } else {
-                    results[resultIndex++] = null;
-                }
+                results[resultIndex++] = row.get(zielattributGen) == null ? null : row.get(zielattributGen).toString();
+                results[resultIndex++] = row.get(zielattribut) == null ? null : row.get(zielattribut).toString();
             }
 
             // Initialize all display variables

--- a/src/main/webapp/forms/noarray.dateRO.jsp
+++ b/src/main/webapp/forms/noarray.dateRO.jsp
@@ -5,6 +5,7 @@
 <%
     if (feldtyp.equals("dateRO") && !array) {
 
+        // Build Query + get all relevant field from DB table
         String[] zielattributArray = zielAttribut.split(";");
         for (int i = 0; i < zielattributArray.length; i++) {
             zielattributArray[i] = zielattributArray[i].trim();
@@ -22,22 +23,29 @@
                 + zielTabelle + " WHERE ID ='" + id + "'");
 
         if (row != null) {
-
+            // Build up "results" array with same indexes as zielAttributArray
             int resultIndex = 0;
             for (String zielattribut : zielattributArray) {
                 String zielattributGen = "Genauigkeit" + zielattribut;
                 if (row.get(zielattributGen) != null) {
                     results[resultIndex++] = row.get(zielattributGen).toString();
+                } else {
+                    results[resultIndex++] = null;
                 }
                 if (row.get(zielattribut) != null) {
                     results[resultIndex++] = row.get(zielattribut).toString();
+                } else {
+                    results[resultIndex++] = null;
                 }
             }
+
+            // Initialize all display variables
             String von = "";
             String vonGen = "";
             String bis = "";
             String bisGen = "";
 
+            // Generate von + vonGen
             for (int i = 0; i < zielattributArray.length - 1; i++) {
                 if (i % 2 == 0) {
                     if (vonGen == null || vonGen.equals("") || vonGen.equals("-1")) {
@@ -51,6 +59,8 @@
                                     : "");
                 }
             }
+
+            // Special handling if "von" is empty to use last 2 fields (GenauigkeitBisJahrhundert, BisJahrhundert)
             if (von.equals("")
                     && results[zielattributArray.length - 1] != null
                     && !results[zielattributArray.length - 1]
@@ -60,6 +70,8 @@
                 }
                 von = results[zielattributArray.length - 1];
             }
+
+            // Generate bis + bisGen
             for (int i = zielattributArray.length; i < zielattributArray.length * 2 - 1; i++) {
                 if (i % 2 == 0) {
                     if (bisGen == null || bisGen.equals("") || bisGen.equals("-1")) {
@@ -74,6 +86,7 @@
                 }
             }
 
+            // Lookup vonGen vs selektion_datgenauigkeit
             Map row2 = AbstractBase.getMappedRow("SELECT * FROM selektion_datgenauigkeit WHERE ID=" + vonGen);
             if (row2 != null && !vonGen.equals("-1")) {
                 vonGen = row2.get("Bezeichnung").toString();
@@ -81,6 +94,7 @@
                 vonGen = "";
             }
 
+            // Special handling if "bis" is empty to use last 2 fields (GenauigkeitBisJahrhundert, BisJahrhundert)
             if (bis.equals("")
                     && results[zielattributArray.length - 1] != null
                     && !results[zielattributArray.length - 1]
@@ -91,6 +105,7 @@
                 bis = results[zielattributArray.length * 2 - 1];
             }
 
+            // Lookup bisGen vs selektion_datgenauigkeit
             row2 = AbstractBase.getMappedRow("SELECT * FROM selektion_datgenauigkeit WHERE ID=" + bisGen);
             if (row2 != null && !bisGen.equals("-1")) {
                 bisGen = row2.get("Bezeichnung").toString();
@@ -98,8 +113,13 @@
                 bisGen = "";
             }
 
+            // Print output depeding on whether "bis" is set as well or not
             if (bis != null && von != null && !bis.equals(von) && !bis.equals("")) {
-                out.println(vonGen + " " + von + "-" + bisGen + " " + bis);
+                String vonTotal = vonGen + " " + von;
+                String bisTotal = bisGen + " " + bis;
+                vonTotal = vonTotal.trim();
+                bisTotal = bisTotal.trim();
+                out.println(vonTotal + " - " + bisTotal);
             } else {
                 if (von != null) {
                     out.println(vonGen + " " + von);

--- a/src/main/webapp/forms/noarray.dateRO.jsp
+++ b/src/main/webapp/forms/noarray.dateRO.jsp
@@ -80,11 +80,7 @@
 
             // Lookup vonGen vs selektion_datgenauigkeit
             Map row2 = AbstractBase.getMappedRow("SELECT * FROM selektion_datgenauigkeit WHERE ID=" + vonGen);
-            if (row2 != null && !vonGen.equals("-1")) {
-                vonGen = row2.get("Bezeichnung").toString();
-            } else {
-                vonGen = "";
-            }
+            vonGen = row2 != null && !vonGen.equals("-1") ? String.valueOf(row2.get("Bezeichnung")) : "";
 
             // Special handling if "bis" is empty to use last 2 fields (GenauigkeitBisJahrhundert, BisJahrhundert)
             if (bis.equals("")
@@ -99,11 +95,7 @@
 
             // Lookup bisGen vs selektion_datgenauigkeit
             row2 = AbstractBase.getMappedRow("SELECT * FROM selektion_datgenauigkeit WHERE ID=" + bisGen);
-            if (row2 != null && !bisGen.equals("-1")) {
-                bisGen = row2.get("Bezeichnung").toString();
-            } else {
-                bisGen = "";
-            }
+            bisGen = row2 != null && !bisGen.equals("-1") ? String.valueOf(row2.get("Bezeichnung")) : "";
 
             // Print output depeding on whether "bis" is set as well or not
             if (bis != null && von != null && !bis.equals(von) && !bis.equals("")) {


### PR DESCRIPTION
Alternativer Lösungsvorschlag zu den Änderungen an noarray.dateRO.jsp in #255

Eigentlich besteht das Problem nur darin, dass wenn VonTag, VonMonat etc nicht befüllt (=NULL) sind fälschlicherweise die Genauigkeit...-Werte (-1) als Datumswerte verwendet werden. Das ist mit dieser Änderung nicht mehr der Fall. Sonderfälle wie 0, -1 und so weiter werden in diesem Template auch schon vor dieser Änderung korrekt für die Anzeige umgewandelt. Dieses Template hat ja nichts mit der Speicherung in die DB zu tun  sondern nur mit der Anzeige.

Wie besprochen: Wir mergen den genannten PR #255 zuerst und diesen im Anschluss, mit kleineren Änderungen (insb. shorthand if).