### PR TITLE
Remove unique index mgh_lemma.provenance_id

### DIFF
--- a/updates/julian_1.sql
+++ b/updates/julian_1.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `mgh_lemma` DROP INDEX `unique_provenance_id`;


### PR DESCRIPTION
Für den Import von namen.pn_lemma muss in der Tabelle mgh_lemma der unique index von provenance_id entfernt werden.
Da die Spalte namen.f_id_lemmata nicht ganz sauber gepflegt ist.