### PR TITLE
inc.erzeugeFormular.jsp: Only render table row if value exists

### DIFF
--- a/src/main/java/de/uni_tuebingen/ub/nppm/util/JspWriterStringBuffer.java
+++ b/src/main/java/de/uni_tuebingen/ub/nppm/util/JspWriterStringBuffer.java
@@ -1,0 +1,162 @@
+package de.uni_tuebingen.ub.nppm.util;
+
+import java.io.IOException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * Purpose of this class is to implement a dummy JspWriter that simply
+ * writes added information to a class variable instead of the default output
+ * which can be queried using getBuffer().
+ */
+public class JspWriterStringBuffer extends JspWriter {
+    String buffer = "";
+
+    public JspWriterStringBuffer() {
+        super(12345678, false);
+    }
+
+    public String getBuffer() {
+        return buffer;
+    }
+
+    @Override
+    public int getRemaining() {
+        return bufferSize - buffer.length();
+    }
+
+    @Override
+    public void clear() {
+        buffer = "";
+    }
+
+    @Override
+    public void clearBuffer() {
+        buffer = "";
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void print(Object x) {
+        buffer += x.toString();
+    }
+
+    @Override
+    public void println(Object x) {
+        print(x);
+        println();
+    }
+
+    @Override
+    public void print(String x) {
+        buffer += x;
+    }
+
+    @Override
+    public void println(String x) {
+        print(x);
+        println();
+    }
+
+    @Override
+    public void print(char x) {
+        buffer += x;
+    }
+
+    @Override
+    public void println(char x) {
+        print(x);
+        println();
+    }
+
+    @Override
+    public void print(char[] x) {
+        buffer += x;
+    }
+
+    @Override
+    public void println(char[] x) {
+        print(x);
+        println();
+    }
+
+    @Override
+    public void print(double x) {
+        buffer += x;
+    }
+
+    @Override
+    public void println(double x) {
+        print(x);
+        println();
+    }
+
+    @Override
+    public void print(float x) {
+        buffer += x;
+    }
+
+    @Override
+    public void println(float x) {
+        print(x);
+        println();
+    }
+
+    @Override
+    public void print(long x) {
+        buffer += x;
+    }
+
+    @Override
+    public void println(long x) {
+        print(x);
+        println();
+    }
+
+    @Override
+    public void print(int x) {
+        buffer += x;
+    }
+
+    @Override
+    public void println(int x) {
+        print(x);
+        println();
+    }
+
+    @Override
+    public void print(boolean x) {
+        buffer += Boolean.toString(x);
+    }
+
+    @Override
+    public void println(boolean x) {
+        print(x);
+        println();
+    }
+
+    @Override
+    public void println() {
+        buffer += System.lineSeparator();
+    }
+
+    @Override
+    public void newLine() {
+        println();
+    }
+
+    @Override
+    public void write(char[] chars, int i, int i1) throws IOException {
+        for (int j = i; j <= i1; j++) {
+            print(chars[j]);
+        }
+    }
+}

--- a/src/main/java/de/uni_tuebingen/ub/nppm/util/Language.java
+++ b/src/main/java/de/uni_tuebingen/ub/nppm/util/Language.java
@@ -42,22 +42,30 @@ public class Language {
         }
     }
 
-    public static void printDatafield(JspWriter out,HttpSession session, String formular, String datenfeld) throws Exception{
+    public static String getDatafield(HttpSession session, String formular, String datenfeld) throws Exception {
+        String html = "";
+
         String lang = getLanguage(session);
         String[] langArray = {lang, Constants.DEFAULT_LANG};
         boolean isSet = false;
-        out.print("<label for=\""+datenfeld+"\">");
+        html += "<label for=\""+datenfeld+"\">";
         for(String l : langArray){
             String print = DatenbankDB.getMapping(l, formular, datenfeld);
             if(print != null){
-                out.println(print);
+                html += print;
                 isSet = true;
                 break;
             }
         }
-        out.print("</label>");
+        html += "</label>";
         if(!isSet)
-            out.println("no datafield available: " + formular + " " + datenfeld);
+            html += "no datafield available: " + formular + " " + datenfeld;
+
+        return html;
+    }
+
+    public static void printDatafield(JspWriter out, HttpSession session, String formular, String datenfeld) throws Exception{
+        out.println(getDatafield(session, formular, datenfeld));
     }
 
     public static String getTextfield(HttpSession session, String formular, String textfield) throws Exception {

--- a/src/main/webapp/gast/einzelbeleg.jsp
+++ b/src/main/webapp/gast/einzelbeleg.jsp
@@ -243,17 +243,15 @@
         </jsp:include>
       </td>
     </tr>
-    <tr>
-      <th><% Language.printDatafield(out, session, "einzelbeleg", "Schreiber"); %></th>
-      <td>
-        <jsp:include page="../inc.erzeugeFormular.jsp">
-          <jsp:param name="ID" value="<%= id %>"/>
-          <jsp:param name="Formular" value="einzelbeleg"/>
-          <jsp:param name="Datenfeld" value="Schreiber"/>
-          <jsp:param name="Readonly" value="yes"/>
-        </jsp:include>
-      </td>
-    </tr>
+
+    <jsp:include page="../inc.erzeugeFormular.jsp">
+      <jsp:param name="ID" value="<%= id %>"/>
+      <jsp:param name="Formular" value="einzelbeleg"/>
+      <jsp:param name="Datenfeld" value="Schreiber"/>
+      <jsp:param name="Readonly" value="yes"/>
+      <jsp:param name="Darstellung" value="Tabellenzeile"/>
+      <jsp:param name="Label" value="<%=Language.getDatafield(session, "einzelbeleg", "Schreiber")%>"/>
+    </jsp:include>
   </tbody>
 </table>
 

--- a/src/main/webapp/gast/einzelbeleg.jsp
+++ b/src/main/webapp/gast/einzelbeleg.jsp
@@ -71,17 +71,15 @@
         </jsp:include>
       </td>
     </tr>
-    <tr>
-      <th><% Language.printDatafield(out, session, "einzelbeleg", "LemmaRO"); %></th>
-      <td>
-        <jsp:include page="../inc.erzeugeFormular.jsp">
-          <jsp:param name="ID" value="<%= id %>"/>
-          <jsp:param name="Formular" value="einzelbeleg"/>
-          <jsp:param name="Datenfeld" value="LemmaRO"/>
-          <jsp:param name="Readonly" value="yes"/>
-        </jsp:include>
-      </td>
-    </tr>
+
+    <jsp:include page="../inc.erzeugeFormular.jsp">
+      <jsp:param name="ID" value="<%= id %>"/>
+      <jsp:param name="Formular" value="einzelbeleg"/>
+      <jsp:param name="Datenfeld" value="LemmaRO"/>
+      <jsp:param name="Readonly" value="yes"/>
+      <jsp:param name="Darstellung" value="Tabellenzeile"/>
+      <jsp:param name="Label" value="<%=Language.getDatafield(session, "einzelbeleg", "LemmaRO")%>"/>
+    </jsp:include>
 
      <tr>
       <th><% Language.printDatafield(out, session, "einzelbeleg", "MGHLemmaRO"); %></th>
@@ -243,15 +241,17 @@
         </jsp:include>
       </td>
     </tr>
-
-    <jsp:include page="../inc.erzeugeFormular.jsp">
-      <jsp:param name="ID" value="<%= id %>"/>
-      <jsp:param name="Formular" value="einzelbeleg"/>
-      <jsp:param name="Datenfeld" value="Schreiber"/>
-      <jsp:param name="Readonly" value="yes"/>
-      <jsp:param name="Darstellung" value="Tabellenzeile"/>
-      <jsp:param name="Label" value="<%=Language.getDatafield(session, "einzelbeleg", "Schreiber")%>"/>
-    </jsp:include>
+    <tr>
+      <th><% Language.printDatafield(out, session, "einzelbeleg", "Schreiber"); %></th>
+      <td>
+        <jsp:include page="../inc.erzeugeFormular.jsp">
+          <jsp:param name="ID" value="<%= id %>"/>
+          <jsp:param name="Formular" value="einzelbeleg"/>
+          <jsp:param name="Datenfeld" value="Schreiber"/>
+          <jsp:param name="Readonly" value="yes"/>
+        </jsp:include>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/main/webapp/inc.erzeugeFormular.jsp
+++ b/src/main/webapp/inc.erzeugeFormular.jsp
@@ -20,6 +20,8 @@
   String typeFile = request.getParameter("type");
   String def = "";
   String disabled = "";
+  String darstellung = request.getParameter("Darstellung") != null ? request.getParameter("Darstellung") : "";
+  String label = request.getParameter("Label") != null ? request.getParameter("Label") : "";
 
   boolean isReadOnly = (readonly!=null && readonly.equals("yes"));
   boolean isEmpty = (emp!=null && emp.equals("yes"));
@@ -105,10 +107,15 @@
 
 <% if (visible!=null && visible.equals("hidden")) out.println("<div style=\"visibility:hidden\">");%>
 
+<% if (darstellung.equals("Tabellenzeile")) { %>
+    <tr>
+        <th><%=label%></th>
+        <td>
+<% } %>
+
 <script type="text/javascript">
     var deleteEntryMessage = "<%= deleteEntryMessage %>"; // Java-Variable in JavaScript-Variable umwandeln
 </script>
-
 
 <%@ page import="java.util.*" isThreadSafe="false" %>
 
@@ -140,5 +147,10 @@
 <%@ include file="forms/noarray.textarea.jsp" %>
 <%@ include file="forms/noarray.textfield.jsp" %>
 <%@ include file="forms/noarray.gndlink.jsp" %>
+
+<% if (darstellung.equals("Tabellenzeile")) { %>
+        </td>
+    </tr>
+<% } %>
 
 <% if (visible!=null && visible.equals("hidden")) out.println("</div>");%>

--- a/src/main/webapp/inc.erzeugeFormular.jsp
+++ b/src/main/webapp/inc.erzeugeFormular.jsp
@@ -103,19 +103,18 @@
     combinedFeldtypen = mapping.getCombinedFeldtypenAsArray();
     combinedAnzeigenamen = mapping.getCombinedAnzeigenamenAsArray(sprache);
   }
+
 %>
 
 <% if (visible!=null && visible.equals("hidden")) out.println("<div style=\"visibility:hidden\">");%>
 
-<% if (darstellung.equals("Tabellenzeile")) { %>
-    <tr>
-        <th><%=label%></th>
-        <td>
-<% } %>
-
-<script type="text/javascript">
-    var deleteEntryMessage = "<%= deleteEntryMessage %>"; // Java-Variable in JavaScript-Variable umwandeln
-</script>
+<%
+    // Replace the standard writer with a custom writer that writes to a string variable.
+    // This way we can check whether a value was generated before generating layout like table rows, etc.
+    JspWriter out_html = out;
+    JspWriterStringBuffer out_buffer = new de.uni_tuebingen.ub.nppm.util.JspWriterStringBuffer();
+    out = out_buffer;
+%>
 
 <%@ page import="java.util.*" isThreadSafe="false" %>
 
@@ -148,9 +147,29 @@
 <%@ include file="forms/noarray.textfield.jsp" %>
 <%@ include file="forms/noarray.gndlink.jsp" %>
 
-<% if (darstellung.equals("Tabellenzeile")) { %>
-        </td>
-    </tr>
-<% } %>
+<%
+    // Read the value from buffer & restore our default html writer
+    out = out_html;
+    String generatedValue = out_buffer.getBuffer().trim();
+
+    // Render output if generated value is not empty
+    boolean display = !generatedValue.isEmpty() && !generatedValue.equals("-");
+
+    if (display) {
+        if (darstellung.equals("Tabellenzeile")) {
+            out.print("<tr><th>" + label + "</th><td>");
+        }
+        %>
+        <script type="text/javascript">
+            var deleteEntryMessage = "<%= deleteEntryMessage %>"; // Java-Variable in JavaScript-Variable umwandeln
+        </script>
+        <%
+        out.print(generatedValue);
+
+        if (darstellung.equals("Tabellenzeile")) {
+            out.print("</td></tr>");
+        }
+    }
+%>
 
 <% if (visible!=null && visible.equals("hidden")) out.println("</div>");%>


### PR DESCRIPTION
Sometimes ingenuity & stupidity are very close to one another. This works fine & will hopefully not cause any side effects. (It is a very good workaround & might even be worth posting on stackoverflow.)

The change has only been applied to Einzelbeleg "Philologisches Lemma" so far which is now hidden if not available.

The only thing we need to do now if to change the calls in the affected gast templates wherever inc.erzeugeFormular.jsp is called, e.g. all other fields in einzelbeleg.jsp, and also the other handful of main templates like quelle/person/mghlemma.jsp.